### PR TITLE
VCP documentation updates

### DIFF
--- a/documentation/overview.md
+++ b/documentation/overview.md
@@ -39,7 +39,7 @@ vSphere Cloud Provider supports every storage primitive exposed by Kubernetes -
 * Storage Class
 * Stateful Sets
 
-Persistent volumes requested by stateful containerized applications can be provisioned on VSAN, VVol,VMFS or NFS datastores.
+Persistent volumes requested by stateful containerized applications can be provisioned on VSAN, VVol, VMFS or NFS datastores.
 
 Kubernetes volumes are defined in Pod specification. They reference VMDK files and these VMDK files are mounted as volumes when the container is running. When the Pod is deleted the Kubernetes volume is unmounted and the data in VMDK files persists.
 

--- a/documentation/overview.md
+++ b/documentation/overview.md
@@ -19,15 +19,17 @@ Cloud provider provides following interfaces to effectively integrate cloud plat
 
 
 ## vSphere Storage Concepts
-vSphere is one of the cloud providers of Kubernetes and thus allows Kubernetes Pods use enterprise grade storage. vSphere has a proven Software Defined Storage platform that integrates with block, file and HyperConverged offerings such as VMware VSAN. These storage offerings are exposed as VMFS, NFS and VSAN datastores respectively. SDS platform in vSphere has enterprise grade features like Storage Policy Based Management(SPBM) which enables customers to guarantee QoS requested by their business critical applications and enforce SLAs. vSphere provides various data services out of the box such high availability and data reliability for containers using Kubernetes.
+vSphere is one of the cloud providers of Kubernetes and thus allows Kubernetes Pods use enterprise grade storage. vSphere has a proven Software Defined Storage(SDS) platform that integrates with block, file and HyperConverged offerings such as VMware VSAN. These storage offerings can exposed as VMFS, NFS, VVol and VSAN datastores. SDS platform in vSphere has enterprise grade features like Storage Policy Based Management(SPBM) which enables customers to guarantee QoS requested by their business critical applications and enforce SLAs. vSphere provides various data services out of the box such high availability and data reliability for containers using Kubernetes.
  
-Datastores is an abstraction which hides storage details and provide uniform interface for storing persistent data. Datastores enables simplified storage management with features like grouping them in folders. Depending on the backend storage used, the datastores can be of the type vSAN, VMFS or NFS.
+Datastores is an abstraction which hides storage details and provide uniform interface for storing persistent data. Datastores enables simplified storage management with features like grouping them in folders. Depending on the backend storage used, the datastores can be of the type vSAN, VMFS, NFS & VVol.
  
 * vSAN is a hyper-converged infrastructure storage which provides excellent performance as well as reliability. vSAN advantage is simplified storage management with features like policy driven administration. 
  
-* VMFS (VMware FIle System) is a cluster file system that allows virtualization to scale beyond a single node for multiple VMware ESX servers. VMFS increases resource utilization by providing shared access to pool of storage.
+* VMFS (Virtual Machine File System) is a cluster file system that allows virtualization to scale beyond a single node for multiple VMware ESX servers. VMFS increases resource utilization by providing shared access to pool of storage.
  
 * NFS (Network File System) is distributed file protocol to access storage over network like local storage. vSphere supports NFS as backend to store virtual machines files.
+
+* VVol(Virtual Volumes) - Virtual Volumes datastore represents a storage container in vCenter Server and vSphere Web Client. 
 
 ## Kubernetes Storage support
 vSphere Cloud Provider supports every storage primitive exposed by Kubernetes -
@@ -37,7 +39,7 @@ vSphere Cloud Provider supports every storage primitive exposed by Kubernetes -
 * Storage Class
 * Stateful Sets
 
-Persistent volumes requested by stateful contenarized applications can be provisioned on VSAN, VMFS or NFS datastores.
+Persistent volumes requested by stateful containerized applications can be provisioned on VSAN, VVol,VMFS or NFS datastores.
 
 Kubernetes volumes are defined in Pod specification. They reference VMDK files and these VMDK files are mounted as volumes when the container is running. When the Pod is deleted the Kubernetes volume is unmounted and the data in VMDK files persists.
 


### PR DESCRIPTION
1. Fixed typos. Fixes https://github.com/vmware/kubernetes/issues/400
2. Added VVol to the supported datastores list. Fixes #https://github.com/vmware/kubernetes/issues/388