### PR TITLE
Adds note to prereqs page regarding standalone ESX

### DIFF
--- a/documentation/prerequisites.md
+++ b/documentation/prerequisites.md
@@ -18,7 +18,7 @@ Following table summarizes key features introduced in vSphere Cloud Provider in 
 | v1.8.2 | Performance improvement for large scale deployment |
 | v1.9.0 | Multi vCenter Support |
 
-* vSphere version - 6.0.x (Virtual Hardware 11) and above
+* vSphere version - 6.0.x (Virtual Hardware 11) and above. (**Note:** Standalone ESX is not supported.)
 
 * Container Host operating systems -
     - Photon - v1.0 GA


### PR DESCRIPTION
This PR adds a note to the `prerequisites` page that standalone ESX isn't supported. See vmware/kubernetes#465 for more information.