### PR TITLE
Fix description for datastore path

### DIFF
--- a/documentation/storageclass.md
+++ b/documentation/storageclass.md
@@ -40,11 +40,12 @@ parameters:
   fstype: ext3
 ```
 
-If datastore is a member of datastore Cluster or within some subfolder, the datastore folder path needs to be provided in the datastore parameter as below.
+For Kubernetes version 1.8.X or older, if datastore is a member of datastore Cluster or within some subfolder, the datastore folder path needs to be provided in the datastore parameter as below.
 
 ```
    datastore:	DatastoreCluster/VSANDatastore
 ```
+For Kubernetes version 1.9.X datastore name is sufficient to identify the datastore.
 
 **Create the Storageclass**
 


### PR DESCRIPTION
We need to explicitly call out that 1.8 and older versions need path to be specified and 1.9 only requires name. https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html already calls this out.