### PR TITLE
Improved VCP Documentation

### DIFF
--- a/documentation/_data/sidebars/home_sidebar.yml
+++ b/documentation/_data/sidebars/home_sidebar.yml
@@ -49,6 +49,9 @@ entries:
       - title: Configurations on existing Kubernetes Cluster
         url: /existing.html
         output: web
+      - title: SAML token authentication
+        url: /saml-token-authentication.html
+        output: web
       - title: Customize roles and privileges
         url: /vcp-roles.html
         output: web
@@ -85,9 +88,3 @@ entries:
         - title: Known Issues
           url: /known-issues.html
           output: web
-
-
-
-
-
-

--- a/documentation/contactus.md
+++ b/documentation/contactus.md
@@ -6,4 +6,4 @@ Please reach us via:
 
 * [hatchway@vmware.com](hatchway@vmware.com)
 * [Issues](https://github.com/vmware/kubernetes/issues)
-* [VMware{code} Kubernetes Slack](https://vmwarecode.slack.com/messages/kubernetes) channel
+* [sig-vmware Kubernetes Slack](https://kubernetes.slack.com/messages/sig-vmware) channel

--- a/documentation/existing.md
+++ b/documentation/existing.md
@@ -51,7 +51,7 @@ datacenters = "us-east"
 server = "1.1.1.1"
 datacenter = "us-east"
 default-datastore="sharedVmfs-0"
-resourcepool-path=""
+resourcepool-path="cluster-folder/cluster-name/Resources"
 folder = "kubernetes"
 
 [Disk]
@@ -88,7 +88,7 @@ datacenters = "us-west"
 server = "1.1.1.1"
 datacenter = "us-east"
 default-datastore="sharedVmfs-0"
-resourcepool-path=" "
+resourcepool-path="cluster-folder/cluster-name/Resources"
 folder = "kubernetes"
 
 [Disk]
@@ -105,11 +105,11 @@ Below is the summary of supported parameters in the `vsphere.conf` file for Kube
 * ```insecure-flag``` should be set to 1 if the vCenter uses a self-signed cert.
 * ```datacenters``` should be the list of all comma separated datacenters where Kubernetes node VMs are present.
 * ```default-datastore``` is the default datastore to use for provisioning volumes using storage classes/dynamic provisioning.
-* ```Workspace``` Workspace is used by vSphere Cloud Provider to know which virtual center, datacenter, folder, resourcepool pool to use for dynamic provisioning volumes using SPBM profile.
-   * ```server``` is the virtual center server on which the dummy/shadow VM for storage profile based volumes should be created.
-   * ```datacenter``` is the name of datacenter on which the dummy/shadow VM should be created.
-   * ```folder``` is the virtual center VM folder path under which the dummy VMs should be placed.
-   * ```resourcepool-path``` is the path to resource pool where dummy VMs for Storage Profile Based volume provisioning should be created.
+* ```Workspace``` is used by vSphere Cloud Provider for provisioning volumes using SPBM storage policy. The following configuration specifies the location vSphere Cloud Provider uses to create temporary VMs for volume provisioning:
+   * ```server``` is the virtual center server
+   * ```datacenter``` is the name of datacenter in the virtual center server
+   * ```folder``` is the virtual center VM folder path under the datacenter
+   * ```resourcepool-path``` is the path to resource pool under the datacenter
 
 If exposing vsphere username and password in plain text, is the security concern, username and password can be put in the [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 This feature is available as of Kubernetes release 1.11.
@@ -258,7 +258,7 @@ Below is the summary of supported parameters in the `vsphere.conf` file
 * Reload kubelet systemd unit file using ```systemctl daemon-reload```
 * Restart kubelet service using ```systemctl restart kubelet.service```
 
-* If controller-Manager is running in the container, kill and restart controller-Manager container. If controller-Manager is running as service, restart service for controller-Manager.
+* If controller-Manager is running in the container, restart controller-Manager container. If controller-Manager is running as service, restart service for controller-Manager.
 
 ```
 root@kubernetes-master [ ~ ]# docker ps | grep controller
@@ -266,7 +266,7 @@ root@kubernetes-master [ ~ ]# docker ps | grep controller
 3b99b40f61c1        k8s.gcr.io/pause:3.1                       "/pause"                 40 hours ago        Up 40 hours                             k8s_POD_kube-controller-manager-kubernetes-master_kube-system_9dd546d79c93e3b5a15fc6dc073c2c54_0
 
 
-root@kubernetes-master [ ~ ]# docker kill 8350dcd5ccd1
+root@kubernetes-master [ ~ ]# docker stop 8350dcd5ccd1
 8350dcd5ccd1
 
 
@@ -276,7 +276,7 @@ root@kubernetes-master [ ~ ]# docker ps | grep controller
 root@kubernetes-master [ ~ ]#
 ```
 
-* If API server is running in the container, kill and restart API container. If API server is running as service, restart service for API server.
+* If API server is running in the container, restart API container. If API server is running as service, restart service for API server.
 
 ```
 root@kubernetes-master [ ~ ]# docker ps | grep apiserver
@@ -284,7 +284,7 @@ root@kubernetes-master [ ~ ]# docker ps | grep apiserver
 37e1ca788144        k8s.gcr.io/pause:3.1                       "/pause"                 40 hours ago         Up 40 hours                             k8s_POD_kube-apiserver-kubernetes-master_kube-system_6729daafa7d07bc748843414a6839053_0
 
 
-root@kubernetes-master [ ~ ]# docker kill 4b76d2fb16be
+root@kubernetes-master [ ~ ]# docker stop 4b76d2fb16be
 4b76d2fb16be
 
 

--- a/documentation/existing.md
+++ b/documentation/existing.md
@@ -258,6 +258,40 @@ Below is the summary of supported parameters in the `vsphere.conf` file
 * Reload kubelet systemd unit file using ```systemctl daemon-reload```
 * Restart kubelet service using ```systemctl restart kubelet.service```
 
-If Controller-Manager and API Server is running in the containers, kill and restart Controller-Manager and API Server containers after restarting kubelet on the node.
+* If controller-Manager is running in the container, kill and restart controller-Manager container. If controller-Manager is running as service, restart service for controller-Manager.
+
+```
+root@kubernetes-master [ ~ ]# docker ps | grep controller
+8350dcd5ccd1        a874414bbabd                               "/hyperkube controlle"   About an hour ago   Up About an hour                        k8s_kube-controller-manager_kube-controlle-manager-kubernetes-master_kube-system_9dd546d79c93e3b5a15fc6dc073c2c54_5
+3b99b40f61c1        k8s.gcr.io/pause:3.1                       "/pause"                 40 hours ago        Up 40 hours                             k8s_POD_kube-controller-manager-kubernetes-master_kube-system_9dd546d79c93e3b5a15fc6dc073c2c54_0
+
+
+root@kubernetes-master [ ~ ]# docker kill 8350dcd5ccd1
+8350dcd5ccd1
+
+
+root@kubernetes-master [ ~ ]# docker ps | grep controller
+298f6d3edd5a        a874414bbabd                               "/hyperkube controlle"   4 seconds ago       Up 4 seconds                            k8s_kube-controller-manager_kube-controlle-manager-kubernetes-master_kube-system_9dd546d79c93e3b5a15fc6dc073c2c54_6
+3b99b40f61c1        k8s.gcr.io/pause:3.1                       "/pause"                 40 hours ago        Up 40 hours                             k8s_POD_kube-controller-manager-kubernetes-master_kube-system_9dd546d79c93e3b5a15fc6dc073c2c54_0
+root@kubernetes-master [ ~ ]#
+```
+
+* If API server is running in the container, kill and restart API container. If API server is running as service, restart service for API server.
+
+```
+root@kubernetes-master [ ~ ]# docker ps | grep apiserver
+4b76d2fb16be        a874414bbabd                               "/hyperkube apiserver"   40 hours ago         Up 40 hours                             k8s_kube-apiserver_kube-apiserver-kubernetes-master_kube-system_6729daafa7d07bc748843414a6839053_0
+37e1ca788144        k8s.gcr.io/pause:3.1                       "/pause"                 40 hours ago         Up 40 hours                             k8s_POD_kube-apiserver-kubernetes-master_kube-system_6729daafa7d07bc748843414a6839053_0
+
+
+root@kubernetes-master [ ~ ]# docker kill 4b76d2fb16be
+4b76d2fb16be
+
+
+root@kubernetes-master [ ~ ]# docker ps | grep apiserver
+e33dc8074088        a874414bbabd                               "/hyperkube apiserver"   3 seconds ago        Up 2 seconds                            k8s_kube-apiserver_kube-apiserver-kubernetes-master_kube-system_6729daafa7d07bc748843414a6839053_1
+37e1ca788144        k8s.gcr.io/pause:3.1                       "/pause"                 40 hours ago         Up 40 hours                             k8s_POD_kube-apiserver-kubernetes-master_kube-system_6729daafa7d07bc748843414a6839053_0
+root@kubernetes-master [ ~ ]#
+```
 
 **Note: For Kubernetes version 1.8.x or below, after enabling the vSphere Cloud Provider, Node names will be set to the VM names from the vCenter Inventory**

--- a/documentation/existing.md
+++ b/documentation/existing.md
@@ -14,7 +14,6 @@
 
 **Prerequisites for Kubernetes version is 1.8.x or below.**
 
-* The node host name must be same as the VM name.
 * Node host names must comply with the regex `[a-z](([-0-9a-z]+)?[0-9a-z])?(\.[a-z0-9](([-0-9a-z]+)?[0-9a-z])?)*` and must also comply with these restrictions:
   * They must not begin with numbers.
   * They must not use capital letters.
@@ -106,12 +105,11 @@ Below is the summary of supported parameters in the `vsphere.conf` file for Kube
 * ```insecure-flag``` should be set to 1 if the vCenter uses a self-signed cert.
 * ```datacenters``` should be the list of all comma separated datacenters where Kubernetes node VMs are present.
 * ```default-datastore``` is the default datastore to use for provisioning volumes using storage classes/dynamic provisioning.
-* ```Workspace``` section specify properties which will be used for various vSphere Cloud Provider functionality. e.g. Dynamic provisioning, Storage Profile Based Volume provisioning etc.
-   * ```server``` specified in this section should have the master node VM.
-   * ```datacenter``` is the name of datacenter on which specified VM folder, datastore and resource pool should be present.
-   * ```folder``` is the vCenter VM folder path in which dummy VMs should be created.
-   * ```resourcepool-path``` is the path to resource pool where dummy VMs for Storage Profile Based volume provisioning should be created. It is an optional parameter.
-
+* ```Workspace``` Workspace is used by vSphere Cloud Provider to know which virtual center, datacenter, folder, resourcepool pool to use for dynamic provisioning volumes using SPBM profile.
+   * ```server``` is the virtual center server on which the dummy/shadow VM for storage profile based volumes should be created.
+   * ```datacenter``` is the name of datacenter on which the dummy/shadow VM should be created.
+   * ```folder``` is the virtual center VM folder path under which the dummy VMs should be placed.
+   * ```resourcepool-path``` is the path to resource pool where dummy VMs for Storage Profile Based volume provisioning should be created.
 
 If exposing vsphere username and password in plain text, is the security concern, username and password can be put in the [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 This feature is available as of Kubernetes release 1.11.
@@ -240,7 +238,7 @@ Below is the summary of supported parameters in the `vsphere.conf` file
     --cloud-config=<Path of the vsphere.conf file>
     ```
 
-* Add following flags to kubelet running on each worker node.
+* Add following flags to kubelet running on each worker node. On the worker node, we do not require vsphere.conf file hence `--cloud-config=` flag should not be set for Kubelet for worker nodes.
 
     ```
     --cloud-provider=vsphere
@@ -248,16 +246,18 @@ Below is the summary of supported parameters in the `vsphere.conf` file
 
 ### For Kubernetes version 1.8.x or below
 
-* Add following flags to the kubelet configuration, controller-manager manifest file and API server manifest file on the master node.
+* Add following flags to kubelet running on all nodes and controller-manager's and API server's manifest file on the master node.
 
     ```
     --cloud-provider=vsphere
     --cloud-config=<Path of the vsphere.conf file>
     ```
 
-## 4. Restart Kubelet on all nodes
+## 4. Restart Controller-Manager, API Server and Kubelet on all nodes.
 
 * Reload kubelet systemd unit file using ```systemctl daemon-reload```
 * Restart kubelet service using ```systemctl restart kubelet.service```
+
+If Controller-Manager and API Server is running in the containers, kill and restart Controller-Manager and API Server containers after restarting kubelet on the node.
 
 **Note: For Kubernetes version 1.8.x or below, after enabling the vSphere Cloud Provider, Node names will be set to the VM names from the vCenter Inventory**

--- a/documentation/prerequisites.md
+++ b/documentation/prerequisites.md
@@ -8,15 +8,45 @@ Following is the list of prerequisites for running Kubernetes with vSphere Cloud
 
 Following table summarizes key features introduced in vSphere Cloud Provider in each Kubernetes release
 
-| Kubernetes Release | vSphere Cloud Provider feature |
-| ------ | ------ |
-| v1.6.3 | Dynamic volume provisioning using vSAN storage capabilities |
-| v1.6.5 | Integration with vSphere HA |
-| v1.7.0 | Integration with vSphere Storage Policy Based Management (SPBM) for dynamic volume provisioning |
-| v1.7.0 | Enhanced vSphere Cloud Provider debuggabilty via integration with metrices exposed for Kubernetes storage APIs |
-| v1.8.0 | vSphere Cloud Provider refactoring for better debuggability, logging and code maintenance |
-| v1.8.2 | Performance improvement for large scale deployment |
-| v1.9.0 | Multi vCenter Support |
+<table>
+<thead>
+<tr>
+  <th>Kubernetes Release</th>
+  <th>vSphere Cloud Provider feature</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>v1.11.0</td>
+  <td>Added a mechanism in vSphere Cloud Provider to get credentials from Kubernetes secrets, rather than the plain text vsphere.conf file<br>SAML token authentication support</td>
+</tr>
+<tr>
+  <td>v1.9.0 </td>
+  <td>Multi vCenter Support</td>
+</tr>
+<tr>
+  <td>v1.8.2</td>
+  <td>Performance improvement for large scale deployment</td>
+</tr>
+<tr>
+  <td>v1.8.0</td>
+  <td>vSphere Cloud Provider refactoring for better debuggability, logging and code maintenance</td>
+</tr>
+<tr>
+  <td>v1.7.0</td>
+  <td>Integration with vSphere Storage Policy Based Management (SPBM) for dynamic volume provisioning.<br>Enhanced vSphere Cloud Provider debuggabilty via integration with metrices exposed for Kubernetes storage APIs.</td>
+</tr>
+<tr>
+  <td>v1.6.5</td>
+  <td>Integration with vSphere HA</td>
+</tr>
+<tr>
+  <td>v1.6.3</td>
+  <td>Dynamic volume provisioning using vSAN storage capabilities</td>
+</tr>
+</tbody>
+</table>
+
 
 * vSphere version - 6.0.x (Virtual Hardware 11) and above. (**Note:** Standalone ESX is not supported.)
 
@@ -51,4 +81,3 @@ configuration:
     - VM names can not have capital letters, any special characters except `.` and `-`.
     - VM names can not be shorter than 3 chars and longer than 63
 * The disk.EnableUUID parameter must be set to "TRUE" for each Node VM. Please refer this [section.](/vsphere-storage-for-kubernetes/documentation/existing.html#enable-disk-uuid-on-node-virtual-machines)
-

--- a/documentation/saml-token-authentication.md
+++ b/documentation/saml-token-authentication.md
@@ -1,0 +1,70 @@
+---
+  title: SAML token authentication
+---
+
+As of Kubernetes [release 1.11](https://github.com/kubernetes/kubernetes/releases/tag/v1.11.0), the vSphere Cloud Provider includes support for SAML token authentication using the vCenter [SSO API](https://code.vmware.com/apis/34/vcenter-sso).
+Currently, VCP only issues Holder-of-Key tokens which require a vCenter Solution User and key pair for signing SAML requests.
+The preexisting VCP configuration user and password options can be set to the Solution User's public and private keys to enable this feature. A vCenter Solution User can only use public key authentication via SAML, a Solution User does not have a plain text password.
+
+We expect to enhance the SSO related configuration options in future versions of vSphere Cloud Provider. This includes the ability for a Solution User to act as an existing Person User, but a Solution User is required in either case.
+
+
+## Generate a self-signed certificate
+
+```
+% openssl req -newkey rsa:2048 -x509 -days 365 -nodes -keyout k8s-vcp.key -out k8s-vcp.crt -subj "/C=US/ST=CA/L=SF/O=VMware/OU=CNA/CN=www.vmware.com"
+Generating a 2048 bit RSA private key
+...............................+++
+...............................................................................+++
+writing new private key to 'k8s-vcp.key'
+-----
+```
+
+## Create a solution user
+Using [govc v0.18](https://github.com/vmware/govmomi/releases/tag/v0.18.0) or higher:
+
+```
+% govc sso.user.create -A -R Administrator -C "$(cat k8s-vcp.crt)" k8s-vcp
+```
+
+Or, using [dir-cli](https://www.virtuallyghetto.com/2015/05/vcenter-server-6-0-tidbits-part-9-creating-managing-sso-users-using-dir-cli.html):
+
+```
+% /usr/lib/vmware-vmafd/bin/dir-cli service create --wstrustrole --ssoadminrole Administrator --cert k8s-vcp.crt --name k8s-vcp
+Service [k8s-vcp] created successfully
+```
+
+The example openssl command can be run anywhere, but if you use dir-cli to create the solution user, the public key will need to be local to the vCenter machine. The public key file can be removed from the vCenter machine after the user is created.
+
+The Administrator role used in the examples above can be replaced with any role name that contains the minimal [privileges required](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/vcp-roles.html#minimal-set-of-vsphere-rolesprivileges-required-for-dynamic-persistent-volume-provisioning-with-storage-policy-based-volume-placement).
+
+A users role can be changed using the update command, for example:
+
+```
+% govc sso.user.update -R k8s-role-name k8s-vcp
+```
+When a solution user is created, it will automatically be added to the SolutionUsers group. There are no other roles or permissions required for solution users. A user's role and group membership can be viewed using the ```govc sso.user.id``` command:
+
+```
+% govc sso.user.id k8s-vcp
+solution=k8s-vcp@vsphere.local groups=LicenseService.Administrators,ActAsUsers,Administrators,Everyone,SystemConfiguration.Administrators,SolutionUsers
+```
+
+## Cloud config options
+vSphere Cloud Provider will use SAML token authentication if the user config option is set a PEM encoded public key and password option to the private key.
+**Note** that newlines in ```gcfg``` values must be escaped, which can be scripted for example:
+
+```
+% cat <<EOF
+[VirtualCenter "$(govc env -x GOVC_URL_HOST)"]
+        user = "$(awk '{printf "%s\\n", $0}' k8s-vcp.crt)"
+        password = "$(awk '{printf "%s\\n", $0}' k8s-vcp.key)"
+EOF
+```
+Resulting in:
+
+```
+VirtualCenter "example-vcenter.eng.vmware.com"]
+    user = "-----BEGIN CERTIFICATE-----\nMIIDkTCCAnmgAwIBAgIJALVKv3+BwTORMA0GCSqGSIb3DQEBCwUAMF8xCzAJBgNV\nBAYTAlVTMQswCQYDVQQIDAJDQTELMAkGA1UEBwwCU0YxDzANBgNVBAoMBlZNd2Fy\nZTEMMAoGA1UECwwDQ05BMRcwFQYDVQQDDA53d3cudm13YXJlLmNvbTAeFw0xODA2\nMTEyMTAzMTdaFw0xOTA2MTEyMTAzMTdaMF8xCzAJBgNVBAYTAlVTMQswCQYDVQQI\nDAJDQTELMAkGA1UEBwwCU0YxDzANBgNVBAoMBlZNd2FyZTEMMAoGA1UECwwDQ05B\nMRcwFQYDVQQDDA53d3cudm13YXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEP\nADCCAQoCggEBALChi3frVLyKG2KC9SQyidW5Ji2iOaDMxRZvQiDw/3oNvpFa4oPa\nROFkoi/0uFPLcBhJsduGDnb2gRafNnc+CjvwrqaEESKBgUT6fbtq+ECgV+YJvVs2\nNYdG3ScmLkvr8d5yHDdaVYF5ccq/Z4s6+alc8wHMUyayoqtXTYXf3ksoTgz/z+gD\nQoy5JWXUzfkwvQ5eJs8SVgioLkeNoZ6RMHJCzt9ZUf1pXiuH0fUR9XSz5k/2clRV\nHRnXCPbqBtuBOn15eyr5Ssy4lHb+DYHE0k5KiQNc6lDlPG42hFby+FhOQ0H7RNmV\ncsPKqVsQl918GsKrneM4i4WLF4Wgl1n1f1sCAwEAAaNQME4wHQYDVR0OBBYEFPz1\nmwLeEs3KWF94VdYWxISKwpBCMB8GA1UdIwQYMBaAFPz1mwLeEs3KWF94VdYWxISK\nwpBCMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAIdgpgpFQjSUUiRS\n33PliI9440Ul53/UgWs/0Q0Lmrd1Y07QJ97IgL39zbJBiU8Ndwhup6SEpG/N/F5C\ne3BEZSlM4l6HPpeQ7N8GqMvQt333IvYazKSvMmKisJe6Su7w8NjHbn+yKPDpWc+X\n8dSxqDNbAtTEipHICTUbpuDTM7SF8ZnwdI7viUcMBZOX7cU3uCFC6BqguejLmEH/\neoJtQAwrTrNPakDG77yQyU4EI1Px8CcaxL4pY2DieAkSU8Ors6hZewxC0m9Q0Oth\nsaJY5XigXVGRM7yI23PrZcCBAy7wA1KZNtthSMs1m6zO7NctXm1c/PmYl9PaMWhL\ndUfBxkA=\n-----END CERTIFICATE-----\n"
+    password = "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCwoYt361S8ihti\ngvUkMonVuSYtojmgzMUWb0Ig8P96Db6RWuKD2kThZKIv9LhTy3AYSbHbhg529oEW\nnzZ3Pgo78K6mhBEigYFE+n27avhAoFfmCb1bNjWHRt0nJi5L6/Hechw3WlWBeXHK\nv2eLOvmpXPMBzFMmsqKrV02F395LKE4M/8/oA0KMuSVl1M35ML0OXibPElYIqC5H\njaGekTByQs7fWVH9aV4rh9H1EfV0s+ZP9nJUVR0Z1wj26gbbgTp9eXsq+UrMuJR2\n/g2BxNJOSokDXOpQ5TxuNoRW8vhYTkNB+0TZlXLDyqlbEJfdfBrCq53jOIuFixeF\noJdZ9X9bAgMBAAECggEAQUrWJXQmlLNwwA+s0r6j2Q9iH4hSSTCowkxKY6byqYmf\nIlg4V4k94Ru0IIoUAVW4kCHdz0pU2oDw4w3jslyKp/GmfgNf2iOJR5hZFgjK0Aj1\ntSFwj+EQFHuLkMc6YfJMLHB+IbAQ35WnDM2IVx1r4MFtSwLe0fVC0JerHovMvncA\neVFg2QEcE1cEZKHexBWLmxIvjWb1yK0HET8R2GTcR+NHHRtBoxnXHHBLX+OxP55s\n6lsc8+jW6W9to5iMZOSzJH4WEyQ3ltg8HLbofrC6t6yzXSM4hvPD8fTpJsgogrrX\nZODltvBiqoZ8u36GHgrgeV5RK1pb+2QV/vvSJulhQQKBgQDXgy0OrTcMHhrk/3RP\nAp2A8LmPYJFVl1xSu6hWR4q0z/Jbjhf2nXBYDi/r2jMsQkowtcJx7qacyoaKvzij\ndmpNJQVygmi/p+vdi4Hsf3VRy0VbY4qobkvpRP1TirPAe2nkQSdjodc0MSNAJnyj\n1hBxxDg9zy3RSlUoYmihN7qCEQKBgQDR0GnXoMVwL/xSv4ozSBuo/kgkuAvB008H\nzIB42QlD+r6yluj8ipsvbeR8fq0miInplaNH8nsNNZyLSfN0SX9qMckdVgLJthQu\nQV0s7tqiroVTZJ4vmiW7VcP3zUTItUWmrDPoZ7eMjINHdD4L3M2iJNJ+xNB3mPDP\nbL8wHli+qwKBgBuBFkMFQD0/qlcHcySSRN+r2UK/JE00IAg/AuDgCIfC8j9VByHm\nPew/A0aqdlVzsFw/Fi3MM19XSYxzkxrphe+KhgNzOUMcfzGrGE3ChoqF0rgzIAMW\n8IE42MvMq9wo4/7JgelpQjna+5C4WLfgHgEm9baNtl87iVq6FHhe0GLBAoGALrMf\ny9HKAFV96QEfBpkHJw8qCZo5a7PXxFmdQsi0CkB2T5PNWeCT9/OSxq7/ZTNA1w/q\nXuo2v1LufAZCvOBbDsz0AaaSSklPppf/4C9t1IXZwR0FJH0/5rmJO8+hfrbyQM3V\nY+Yp8YuY8L+Ly+IilvNxMqwl5mjROKnwyAoJIK8CgYBUUtjoTYneBeOSIiHYaHgB\noPSMATyVvx1wSnPQU0Z7CXLWfLcdWd48+YxxY+CLT+O7LeD1HJBuL+clUkk3LLSU\nq7Gwz7JttCax67VJ+Rvca/Ye99Z08San+oyleOc4vaWn+m3elfLYY35I6q2mjEGH\nK6YwNTQeE+GxGIJJncNJXQ==\n-----END PRIVATE KEY-----\n"
+```


### PR DESCRIPTION
* Clarified putting cloud provider configuration for each releases in separate sections.
* Added steps for storing vsphere credentials to secrets.
* Added documentation for SAML token authentication feature.
* Updated configuration steps, and mentioned only master node requires vspehre.conf file with credentials and on the worker node we just need ` --cloud-provider=vsphere` flag.
* Updated feature list in the Prerequisites section for release 1.11.
* Directed user to read about roles and privileges from https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/vcp-roles.html

Issues: https://github.com/vmware/kubernetes/issues/479, https://github.com/vmware/kubernetes/issues/491


@dougm @SandeepPissay @embano1 @BaluDontu Please take a look.
