### PR TITLE
VirtualMachine.Config.Settings privilege is required to create PVC

### DIFF
--- a/documentation/vcp-roles.md
+++ b/documentation/vcp-roles.md
@@ -25,7 +25,7 @@ https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.h
 
 | Roles         | Privileges    | Entities  | Propagate to Children |
 | ------------- |-------------  |-----------| ----------------------|
-| manage-k8s-node-vms | Resource.AssignVMToPool, VirtualMachine.Config.AddExistingDisk, VirtualMachine.Config.AddNewDisk, VirtualMachine.Config.AddRemoveDevice,  VirtualMachine.Config.RemoveDisk, VirtualMachine.Inventory.Create, VirtualMachine.Inventory.Delete | Cluster, Hosts, VM Folder | Yes |
+| manage-k8s-node-vms | Resource.AssignVMToPool, VirtualMachine.Config.AddExistingDisk, VirtualMachine.Config.AddNewDisk, VirtualMachine.Config.AddRemoveDevice,  VirtualMachine.Config.RemoveDisk, VirtualMachine.Inventory.Create, VirtualMachine.Inventory.Delete, VirtualMachine.Config.Settings | Cluster, Hosts, VM Folder | Yes |
 | manage-k8s-volumes | Datastore.AllocateSpace, Datastore.FileManagement (Low level file operations) | Datastore | No |
 | k8s-system-read-and-spbm-profile-view | StorageProfile.View (Profile-driven storage view) | vCenter | No |
 | Read-only (pre-existing default role) | System.Anonymous, System.Read, System.View | Datacenter, Datastore Cluster, Datastore Storage Folder | No |


### PR DESCRIPTION
Create pvc fails without this privilege. From vpxd.logs, you can see the error.

2018-09-20T22:59:13.373Z verbose vpxd[19781] [Originator@6876 sub=Vmomi opID=425a4582] Invoke error: vim.VirtualMachine.reconfigure session: 52be877a-1b22-895b-b649-2ab2a316d2dd Throw: vim.fault.NoPermission
--> Result:
--> (vim.fault.NoPermission) {
--> faultCause = (vmodl.MethodFault) null,
--> faultMessage = ,
--> object = 'vim.VirtualMachine:062c91bf-b47a-4d96-a87d-d10505e90978:vm-93',
--> privilegeId = "VirtualMachine.Config.Settings"
--> msg = "Permission to perform this operation was denied."
--> }