### PR TITLE
Updated privileges required for zone

### DIFF
--- a/documentation/vcp-roles.md
+++ b/documentation/vcp-roles.md
@@ -16,7 +16,7 @@ In general, vSphere user designated for vSphere Cloud Provider should have
 | ------------- |-------------  |-----------| ----------------------|
 | manage-k8s-node-vms | VirtualMachine.Config.AddExistingDisk, VirtualMachine.Config.AddNewDisk, VirtualMachine.Config.AddRemoveDevice, VirtualMachine.Config.RemoveDisk | VM Folder | Yes |
 | manage-k8s-volumes | Datastore.FileManagement (Low level file operations) | Datastore | No |
-| Read-only (pre-existing default role) | System.Anonymous, System.Read, System.View | vCenter, Datacenter, Datastore Cluster, Datastore Storage Folder | No |
+| Read-only (pre-existing default role) | System.Anonymous, System.Read, System.View | vCenter, Datacenter, Datastore Cluster, Datastore Storage Folder, Cluster, Hosts | No |
 
 ## Minimal set of vSphere roles/privileges required for dynamic persistent volume provisioning with storage policy based volume placement.
 
@@ -37,4 +37,4 @@ https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.h
 | ------------- |-------------  |-----------| ----------------------|
 | manage-k8s-node-vms | VirtualMachine.Config.AddExistingDisk, VirtualMachine.Config.AddNewDisk,  VirtualMachine.Config.AddRemoveDevice, VirtualMachine.Config.RemoveDisk | VM Folder | Yes |
 | manage-k8s-volumes | Datastore.AllocateSpace, Datastore.FileManagement (Low level file operations) | Datastore | No |
-| Read-only (pre-existing default role) | System.Anonymous, System.Read, System.View | vCenter, Datacenter, Datastore Cluster, Datastore Storage Folder | No |
+| Read-only (pre-existing default role) | System.Anonymous, System.Read, System.View | vCenter, Datacenter, Datastore Cluster, Datastore Storage Folder, Cluster, Hosts | No |


### PR DESCRIPTION
The VCP zone feature is based on tagging the Datacenter/Cluster/Hosts
with the zone and region tags in the vCenter inventory. At startup,
kubelet fetches these tags from VC. The tags API needs System.Read
privilege on the Datacenter, Cluster and Hosts where the k8s node VMs
are running. The privileges needed for a k8s VC user is documented here
https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/vcp-roles.html.
This does not include the System.Read privilege on the Cluster and
Hosts. This leads to a 'NotAuthorized' error seen in kubelet logs at
startup.

See issue where this was reported
https://github.com/kubernetes/kubernetes/issues/73307.
Closes kubernetes/kubernetes#73307

This PR updates the privileges needed for a k8s user to be able to
fetch the tags associated with Datacenter, Cluster and Hosts where the
node VMs are running.