### PR TITLE
Change provisioner to lowercase

### DIFF
--- a/documentation/minio.md
+++ b/documentation/minio.md
@@ -13,7 +13,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: miniosc
-provisioner: Kubernetes.io/vsphere-volume
+provisioner: kubernetes.io/vsphere-volume
 parameters:
     diskformat: thin
  


### PR DESCRIPTION
`provisioner: Kubernetes.io/vsphere-volume` doesn't create persistent volumes.
Changing this to `provisioner: kubernetes.io/vsphere-volume` solves the issue
This was tested on Kubernetes 1.12.7 and Container Linux by CoreOS 2023.5.0 (Rhyolite)