### PR TITLE
Changed provisioner to lowercase

### DIFF
--- a/documentation/minio.md
+++ b/documentation/minio.md
@@ -70,7 +70,7 @@ spec:
   template:
     metadata:
       annotations:
-        pod.alpha.Kubernetes.io/initialized: "true"
+        pod.alpha.kubernetes.io/initialized: "true"
       labels:
         app: minio
     spec:
@@ -102,7 +102,7 @@ spec:
   - metadata:
       name: data
       annotations:
-        volume.beta.Kubernetes.io/storage-class: miniosc
+        volume.beta.kubernetes.io/storage-class: miniosc
     spec:
       accessModes:
         - ReadWriteOnce

--- a/documentation/mongodb.md
+++ b/documentation/mongodb.md
@@ -14,7 +14,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
  name: platinum
-provisioner: Kubernetes.io/vsphere-volume
+provisioner: kubernetes.io/vsphere-volume
 parameters:
  diskformat: thin
 ```
@@ -33,7 +33,7 @@ kind: PersistentVolumeClaim
 metadata:
  name: pvc128gb
  annotations:
-  volume.beta.Kubernetes.io/storage-class: "platinum"
+  volume.beta.kubernetes.io/storage-class: "platinum"
 spec:
  accessModes:
   - ReadWriteOnce

--- a/documentation/statefulsets.md
+++ b/documentation/statefulsets.md
@@ -17,7 +17,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: thin-disk
-provisioner: Kubernetes.io/vsphere-volume
+provisioner: kubernetes.io/vsphere-volume
 parameters:
     diskformat: thin
 ```

--- a/documentation/storageclass.md
+++ b/documentation/storageclass.md
@@ -106,7 +106,7 @@ Events:
   -----------------------------------------------------------
   1m          1m      1   persistentvolume-controller  Normal  Provisioning Succeeded
 
-  Successfully provisioned volume pvc-83295256-f8e0-11e6-8263-005056b2349c using Kubernetes.io/vsphere-volume
+  Successfully provisioned volume pvc-83295256-f8e0-11e6-8263-005056b2349c using kubernetes.io/vsphere-volume
 ```
 
 Persistent Volume is automatically created and is bounded to this pvc.


### PR DESCRIPTION
Same as #48 , apparently this was an issue in more than 1 place...

`provisioner: Kubernetes.io/vsphere-volume` doesn't create persistent volumes.
Changing this to `provisioner: kubernetes.io/vsphere-volume` solves the issue
This was tested on Kubernetes 1.12.7 and Container Linux by CoreOS 2023.5.0 (Rhyolite)
