### PR TITLE
Added a note about mounting vsphere.conf into system containers

### DIFF
--- a/documentation/existing.md
+++ b/documentation/existing.md
@@ -271,6 +271,21 @@ You can see the sections added to a `JSON` configuration below:
                 ],
 ```
 
+In addition, in accordance with the [official cloud provider configuration guide](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#kubeadm), it is necessary to mount the config file to the corresponding apiserver and controller-manager containers. To do that, the manifest files should also have amendments as follows:
+
+   volumeMounts:
+   ...
+   - mountPath: /etc/kubernetes/vsphere.conf
+     name: vsphere-config
+     readOnly: true
+
+and in the volume definitions:
+
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/vsphere.conf
+    name: vsphere-config
+
 ### On the Kubernetes workers
 
 Add following flags to the `kubelet` service configuration (usually in the `systemd` config file).


### PR DESCRIPTION
The default description misses the fact that since Kubernetes version 1.9 additional config files in /etc/kubernetes path should be explicitly mounted into kube-apiserver and kube-controller-manager pods.
Reference: https://github.com/kubernetes/kubeadm/issues/484